### PR TITLE
Update record.ex

### DIFF
--- a/lib/elixir/lib/record.ex
+++ b/lib/elixir/lib/record.ex
@@ -298,6 +298,15 @@ defmodule Record do
   defp create(atom, fields, keyword, caller) do
     in_match = Macro.Env.in_match?(caller)
 
+    #backward compatiblity for Erlang, a :_ key sets all fields to a default value
+    {fields, keyword} = case Dict.pop(keyword, :_) do
+      {nil, _} -> {fields, keyword}
+      {defaultValue, keyword2} -> fields2 = Enum.reduce fields, [], fn({k,v}, acc) ->
+          acc ++ [{k,defaultValue}]
+        end
+        {fields2, keyword2}
+    end
+
     {match, remaining} =
       Enum.map_reduce(fields, keyword, fn({field, default}, each_keyword) ->
         new_fields =


### PR DESCRIPTION
Simple console test:

require Record
defmodule Records do Record.defrecord :rec, [v1: 5, v2: 10, v3: "ababa"] end

require Records
Records.rec()
Records.rec(_: :_)
Records.rec(_: :_, v2: 7)

If Dict is deprecated an option is to use :proplists.get_value/3
